### PR TITLE
Update to marathon version 0.8.1

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -6,4 +6,4 @@
   apt_repository: repo="{{marathon_apt_repo}}" state=present
 
 - name: Install Marathon package
-  apt: pkg=marathon={{marathon_version}}-1.0 state=present update_cache=yes
+  apt: pkg=marathon={{marathon_version}}-1.0.171.ubuntu1404 state=present update_cache=yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 marathon_playbook_version: "0.3.1"
 
 marathon_hostname: "{{ inventory_hostname }}"
-marathon_version: "0.7.6"
+marathon_version: "0.8.1"
 marathon_port: 8080
 marathon_apt_repo: "deb http://repos.mesosphere.io/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 marathon_playbook_version: "0.3.1"
 
 marathon_hostname: "{{ inventory_hostname }}"
-marathon_version: "0.7.5"
+marathon_version: "0.7.6"
 marathon_port: 8080
 marathon_apt_repo: "deb http://repos.mesosphere.io/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 marathon_playbook_version: "0.3.1"
 
 marathon_hostname: "{{ inventory_hostname }}"
-marathon_version: "0.7.3"
+marathon_version: "0.7.5"
 marathon_port: 8080
 marathon_apt_repo: "deb http://repos.mesosphere.io/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main"
 


### PR DESCRIPTION
Updated to marathon 0.8.1. Fixed bug where there is no marathon=0.8.1-1.0 in aptitude, instead it is called 0.8.1-1.0.171.ubuntu1404. The fix uses a wildcard (0.8.1-1.*).