### PR TITLE
CentOS 7 support, test validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - "ansible-playbook -i tests/inventory tests/$SITE --syntax-check"
 
   # Run the role/playbook with ansible-playbook.
-  - "ansible-playbook -i tests/inventory tests/main.yml --connection=local --sudo"
+  - "ansible-playbook -i tests/inventory tests/playbook.yml --connection=local --sudo"
 
   # Healthcheck
   # - "curl http://localhost:8080/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ install:
 
   # Add ansible.cfg to pick up roles path.
   - "{ echo '[defaults]'; echo 'roles_path = ../'; } >> ansible.cfg"
+  
+  # Install Mesosphere, marathon needs it
+  - sudo sh -c "echo 'deb http://repos.mesosphere.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) main' >> /etc/apt/sources.list.d/mesosphere.list"
+  - sudo apt-get update -qq
+  - sudo apt-get install mesos -y --force-yes
+  - sudo sh -c "echo 1 > /etc/zookeeper/conf/myid"
+  - sudo sh -c "echo 'server.1=localhost:2888:3888' >> /etc/zookeeper/conf/zoo.cfg"
+  - sudo service zookeeper restart
+  - sudo service mesos-master restart
 
 script:
   # Check the role/playbook's syntax.
@@ -22,5 +31,3 @@ script:
   # Run the role/playbook with ansible-playbook.
   - "ansible-playbook -i tests/inventory tests/playbook.yml --connection=local --sudo"
 
-  # Healthcheck
-  # - "curl http://localhost:8080/"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,6 @@ marathon_playbook_version: "0.3.1"
 marathon_hostname: "{{ inventory_hostname }}"
 marathon_version: "0.8.1"
 marathon_port: 8080
-marathon_apt_repo: "deb http://repos.mesosphere.io/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main"
 
 # command line flags:
 # https://mesosphere.github.io/marathon/docs/command-line-flags.html

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add mesosphere repo
-  yum: name=http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm state=present
+  yum: name={{ mesosphere_repo }} state=present
 
 - name: Install Marathon
   yum: name=marathon-{{marathon_version}} state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include_vars: "{{ ansible_os_family }}.yml"
+
 - include: Debian.yml
   when: ansible_os_family == "Debian"
 
@@ -11,4 +13,4 @@
   when: haproxy_script_location != ""
 
 - name: Start Marathon service
-  service: name=marathon state=restarted 
+  service: name=marathon state=restarted enabled=yes 

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -4,9 +4,15 @@
   connection: local
   sudo: yes
   
-  roles:
-    - ansible-marathon
+  tasks:
+    - name: Wait for Marathon to be up
+      wait_for: host="{{ansible_default_ipv4.address}}" port=8080 state=started delay=3 timeout=5
+    
+    - name: Test for Marathon ... endpoint
+      get_url: 
+        url="http://{{ansible_default_ipv4.address}}:8080/v2/info" 
+        dest=/tmp/marathon-info
+        force=yes
+      register: status
+      failed_when: "'OK' not in status.msg"
 
-  # tasks:
-    # Ansible does not recommend checking for service status as a test
-    # Need to find a rest endpoint to curl instead

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -6,9 +6,9 @@
   
   tasks:
     - name: Wait for Marathon to be up
-      wait_for: host="{{ansible_default_ipv4.address}}" port=8080 state=started delay=3 timeout=5
+      wait_for: host="{{ansible_default_ipv4.address}}" port=8080 state=started delay=3 timeout=15
     
-    - name: Test for Marathon ... endpoint
+    - name: Test for Marathon info endpoint
       get_url: 
         url="http://{{ansible_default_ipv4.address}}:8080/v2/info" 
         dest=/tmp/marathon-info

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,1 @@
+marathon_apt_repo: "deb http://repos.mesosphere.io/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,9 @@
+os_version: "{{ ansible_lsb.release if ansible_lsb is defined else ansible_distribution_version }}"
+os_version_major: "{{ os_version | regex_replace('^([0-9]+)[^0-9]*.*', '\\\\1') }}"
+
+mesosphere_releases:
+  '6': 'mesosphere-el-repo-6-3.noarch.rpm'
+  '7': 'mesosphere-el-repo-7-1.noarch.rpm'
+
+mesosphere_repo: "http://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
+


### PR DESCRIPTION
Add support for CentOS 7 and complete test playbook by checking Marathon info endpoint.