### PR TITLE
Add supports for environment variables

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,4 +53,25 @@ Vagrant.configure("2") do |config|
     end
   end
 
+  # centos 7:
+  config.vm.define 'centos7' do |c|
+    c.vm.network "private_network", ip: "192.168.100.4"
+    c.vm.box = "centos/7"
+    c.vm.provision "shell" do |s|
+      s.inline = "
+      hostname localhost;
+      iptables -F;
+      service iptables save;
+      rpm -Uvh http://archive.cloudera.com/cdh4/one-click-install/redhat/6/x86_64/cloudera-cdh-4-0.x86_64.rpm;
+      yum -y install zookeeper;
+      zookeeper-server-initialize --myid=1
+      zookeeper-server start;
+      rpm -Uvh http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-2.noarch.rpm;
+      yum install -y epel-release;
+      yum -y install mesos ansible;
+      "
+      s.privileged = true
+    end
+  end
+  
 end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@ marathon_playbook_version: "0.3.1"
 marathon_hostname: "{{ inventory_hostname }}"
 marathon_version: "0.8.1"
 marathon_port: 8080
+marathon_env_java_opts: '-Xmx512m'
+marathon_env_vars:
+  - "JAVA_OPTS={{ marathon_env_java_opts }}"
 
 # command line flags:
 # https://mesosphere.github.io/marathon/docs/command-line-flags.html

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -47,7 +47,6 @@
 - name: Upstrart environment variables 
   lineinfile: dest=/etc/init/marathon.conf backup=yes state=present insertbefore='exec.*' line="env {{ item }}"
   with_items: marathon_env_vars
-#    - "JAVA_OPTS={{ marathon_env_java_opts }}"
   when: etc_init_check.stat.exists == true
   
 - name: systemd environment variables

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Create Marathon conf directory
   file: path=/etc/marathon/conf state=directory
 
@@ -34,3 +35,22 @@
 
 - name: Set --http-port option
   template: src=http_port.j2 dest=/etc/marathon/conf/http_port
+  
+- name: Upstart check
+  stat: path=/etc/init/
+  register: etc_init_check
+
+- name: systemd check
+  stat: path=/usr/lib/systemd/system/
+  register: systemd_check
+  
+- name: Upstrart environment variables 
+  lineinfile: dest=/etc/init/marathon.conf backup=yes state=present insertbefore='exec.*' line="env {{ item }}"
+  with_items: marathon_env_vars
+#    - "JAVA_OPTS={{ marathon_env_java_opts }}"
+  when: etc_init_check.stat.exists == true
+  
+- name: systemd environment variables
+  template: src=sysconfig.j2 dest=/etc/sysconfig/marathon 
+  when: systemd_check.stat.exists == true
+

--- a/templates/sysconfig.j2
+++ b/templates/sysconfig.j2
@@ -1,0 +1,4 @@
+{% for var in marathon_env_vars %}
+{{ var }}
+{% endfor %}
+


### PR DESCRIPTION
Fix for #15. Environment variables are not configurable, with JAVA_OPTS the first supported variable. Use different technique to get that working on upstart and systemd. `/etc/sysconfig/marathon` is used by systemd service unit for loading variables. Upstart script don't have such file, so adding `env` instruction to init file for each configured environment variables.