### PR TITLE
Fix typo in task name

### DIFF
--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -44,7 +44,7 @@
   stat: path=/usr/lib/systemd/system/
   register: systemd_check
   
-- name: Upstrart environment variables 
+- name: Upstart environment variables 
   lineinfile: dest=/etc/init/marathon.conf backup=yes state=present insertbefore='exec.*' line="env {{ item }}"
   with_items: marathon_env_vars
   when: etc_init_check.stat.exists == true


### PR DESCRIPTION
There was a typo in the task name.