### PR TITLE
Fix RedHat os version parsing

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-marathon_playbook_version: "0.3.2"
+marathon_playbook_version: "0.3.3"
 marathon_version: "0.8.1"
 
 # Debian: Mesosphere apt repository URL

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,4 @@
-os_version: "{{ ansible_lsb.release if ansible_lsb is defined else ansible_distribution_version }}"
-os_version_major: "{{ os_version | regex_replace('^([0-9]+)[^0-9]*.*', '\\\\1') }}"
+os_version_major: "{{ ansible_distribution_major_version }}"
 
 mesosphere_releases:
   '6': 'mesosphere-el-repo-6-3.noarch.rpm'


### PR DESCRIPTION
@mhamrah @JasonGiedymin 

I have found the following bug:

 - os_version_major parsing

os_version_major parsing fails with

```bash
       TASK [ansible-marathon : Add mesosphere repo] **********************************
       task path: /tmp/kitchen/roles/ansible-marathon/tasks/RedHat.yml:2
       fatal: [localhost]: FAILED! => {"failed": true, "msg": "'dict object' has no attribute u'\\\\1'"}

```
