### PR TITLE
Update main.yml: add quotes to marathon_port value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ marathon_yum_package: "marathon-{{ marathon_version }}"
 mesosphere_yum_repo: "http://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
 
 marathon_hostname: "{{ inventory_hostname }}"
-marathon_port: 8080
+marathon_port: "8080"
 marathon_env_java_opts: '-Xmx512m'
 marathon_env_vars:
   - "JAVA_OPTS={{ marathon_env_java_opts }}"


### PR DESCRIPTION
value for marathon_port need to be quoted in YAML, 
otherwise playbook may fail as following:  

```
TASK [ansible-marathon : Set --http-port option] *******************************
fatal: [xxx.xxx.xxx.xxx]: FAILED! => {"changed": false, "failed": true, "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/home/ubuntu/.ansible/tmp/ansible-tmp-1463687175.94-43514556173623/lineinfile\", line 2564, in <module>\r\n    main()\r\n  File \"/home/ubuntu/.ansible/tmp/ansible-tmp-1463687175.94-43514556173623/lineinfile\", line 371, in main\r\n    ins_aft, ins_bef, create, backup, backrefs)\r\n  File \"/home/ubuntu/.ansible/tmp/ansible-tmp-1463687175.94-43514556173623/lineinfile\", line 266, in present\r\n    lines.append(line + os.linesep)\r\nTypeError: unsupported operand type(s) for +: 'int' and 'str'\r\n", "msg": "MODULE FAILURE", "parsed": false}
```