### PR TITLE
Optional mesos_role configuration and tags

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,4 @@ haproxy_script_location: "/usr/local/bin"
 # optional
 artifact_store: ""
 checkpoint: "true"
+marathon_mesos_role: ""

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -30,12 +30,20 @@
   template: src=zk.j2 dest=/etc/marathon/conf/zk
   when: marathon_zookeeper_state != ""
 
+- name: Remove optional --mesos_role option
+  file: path=/etc/marathon/conf/mesos_role state=absent
+  when: marathon_mesos_role == ""
+
+- name: Set optional --mesos_role option
+  template: src=mesos_role.j2 dest=/etc/marathon/conf/mesos_role
+  when: marathon_mesos_role != ""
+
 - name: Set --hostname option
   template: src=hostname.j2 dest=/etc/marathon/conf/hostname
 
 - name: Set --http-port option
   template: src=http_port.j2 dest=/etc/marathon/conf/http_port
-  
+
 - name: Upstart check
   stat: path=/etc/init/
   register: etc_init_check
@@ -43,13 +51,12 @@
 - name: systemd check
   stat: path=/usr/lib/systemd/system/
   register: systemd_check
-  
-- name: Upstrart environment variables 
+
+- name: Upstart environment variables
   lineinfile: dest=/etc/init/marathon.conf backup=yes state=present insertbefore='exec.*' line="env {{ item }}"
   with_items: marathon_env_vars
   when: etc_init_check.stat.exists == true
-  
-- name: systemd environment variables
-  template: src=sysconfig.j2 dest=/etc/sysconfig/marathon 
-  when: systemd_check.stat.exists == true
 
+- name: systemd environment variables
+  template: src=sysconfig.j2 dest=/etc/sysconfig/marathon
+  when: systemd_check.stat.exists == true

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -30,12 +30,20 @@
   template: src=zk.j2 dest=/etc/marathon/conf/zk
   when: marathon_zookeeper_state != ""
 
+- name: Remove optional --mesos_role option
+  file: path=/etc/marathon/conf/mesos_role state=absent
+  when: marathon_mesos_role == ""
+
+- name: Set optional --mesos_role option
+  template: src=mesos_role.j2 dest=/etc/marathon/conf/mesos_role
+  when: marathon_mesos_role != ""
+
 - name: Set --hostname option
   template: src=hostname.j2 dest=/etc/marathon/conf/hostname
 
 - name: Set --http-port option
   template: src=http_port.j2 dest=/etc/marathon/conf/http_port
-  
+
 - name: Upstart check
   stat: path=/etc/init/
   register: etc_init_check
@@ -43,7 +51,7 @@
 - name: systemd check
   stat: path=/usr/lib/systemd/system/
   register: systemd_check
-  
+
 - name: Upstart environment variables 
   lineinfile: dest=/etc/init/marathon.conf backup=yes state=present insertbefore='exec.*' line="env {{ item }}"
   with_items: marathon_env_vars

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,14 +3,24 @@
 
 - include: Debian.yml
   when: ansible_os_family == "Debian"
+  tags:
+    - install
 
 - include: RedHat.yml
   when: ansible_os_family == "RedHat"
+  tags:
+    - install
 
 - include: conf.yml
+  tags:
+    - config
 
 - include: haproxy.yml
   when: haproxy_script_location != ""
+  tags:
+    - haproxy
 
 - name: Start Marathon service
-  service: name=marathon state=restarted enabled=yes 
+  service: name=marathon state=restarted enabled=yes
+  tags:
+    - restart

--- a/templates/mesos_role.j2
+++ b/templates/mesos_role.j2
@@ -1,0 +1,1 @@
+{{ marathon_mesos_role }}


### PR DESCRIPTION
Required config to use mesos roles in marathon!

ps: We need to change some more marathon configs from the defaults.
For this I propose a generic solution to write simple string $value
to the file `/etc/marathon/conf/$key' (where the user just has to be careful not to overwrite any existing config, by a bad $key setting).

Would this be a good solution? 
@ernestas-poskus ?
