### PR TITLE
allow setting additional marathon configs using a generic list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,8 @@ haproxy_script_location: "/usr/local/bin"
 artifact_store: ""
 checkpoint: "true"
 marathon_mesos_role: ""
+
+marathon_additional_configs: []
+#    For example:
+#    - name: task_lost_expunge_interval
+#      value: 900000

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -44,6 +44,12 @@
 - name: Set --http-port option
   template: src=http_port.j2 dest=/etc/marathon/conf/http_port
 
+- name: Set additional options
+  template: src=custom_option.j2 dest=/etc/marathon/conf/{{ item.name }}
+  with_items: marathon_additional_configs
+  tags:
+    - config-additional
+
 - name: Upstart check
   stat: path=/etc/init/
   register: etc_init_check

--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -45,7 +45,9 @@
   template: src=http_port.j2 dest=/etc/marathon/conf/http_port
 
 - name: Set additional options
-  template: src=custom_option.j2 dest=/etc/marathon/conf/{{ item.name }}
+  copy:
+    content: "{{ item.value }}"
+    dest: "/etc/marathon/conf/{{ item.name }}"
   with_items: marathon_additional_configs
   tags:
     - config-additional

--- a/templates/custom_option.j2
+++ b/templates/custom_option.j2
@@ -1,0 +1,1 @@
+{{ item.value }}

--- a/templates/custom_option.j2
+++ b/templates/custom_option.j2
@@ -1,1 +1,0 @@
-{{ item.value }}


### PR DESCRIPTION
as proposed in https://github.com/AnsibleShipyard/ansible-marathon/pull/27

Example configs (for which it seems overkill to support settings these in a 'hardcoded way')

```
  marathon_additional_configs:
   - name: task_lost_expunge_interval
     value: 900000
   - name: task_lost_expunge_gc
     value: 3600000
```

Ref: Config example taken from: https://github.com/mesosphere/marathon/issues/616#issuecomment-244843729
