### PR TITLE
Fix error when upstart configuration file is missing

### DIFF
--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -72,8 +72,8 @@
   stat: path=/usr/lib/systemd/system/
   register: systemd_check
 
-- name: Upstart environment variables 
-  lineinfile: dest=/etc/init/marathon.conf backup=yes state=present insertbefore='exec.*' line="env {{ item }}"
+- name: Upstart environment variables
+  lineinfile: dest=/etc/init/marathon.conf backup=yes state=present create=true insertbefore='exec.*' line="env {{ item }}"
   with_items: "{{ marathon_env_vars }}"
   when: etc_init_check.stat.exists == true
   notify: Restart marathon


### PR DESCRIPTION
When installing on Ubuntu 16.04 the /etc/init/marathon.conf file is missing, resulting in an error

This PR fixes the issue by creating the file, if it is missing