### PR TITLE
Fix 'Using bare variables is deprecated' depreciation warning

### DIFF
--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -59,7 +59,7 @@
   copy:
     content: "{{ item.value }}"
     dest: "/etc/marathon/conf/{{ item.name }}"
-  with_items: marathon_additional_configs
+  with_items: "{{ marathon_additional_configs }}"
   notify: Restart marathon
   tags:
     - config-additional


### PR DESCRIPTION
This fixes the following deprecation warning:

> [DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{marathon_additional_configs}}').
This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
