### PR TITLE
Fix checkpoint file always being changed

### DIFF
--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -23,7 +23,7 @@
   notify: Restart marathon
 
 - name: Set optional --checkpoint option
-  file: path=/etc/marathon/conf/?checkpoint state=touch
+  copy: content="" dest=/etc/marathon/conf/?checkpoint
   when: checkpoint != ""
   notify: Restart marathon
 


### PR DESCRIPTION
This prevents restarting marathon when nothing (really) changed.

See http://stackoverflow.com/q/28347717/246263 for more information