### PR TITLE
Let handler (re)start marathon

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,4 +21,4 @@
     - haproxy
 
 - name: Enable Marathon service
-  service: name=marathon enabled=yes state=started
+  service: name=marathon enabled=yes


### PR DESCRIPTION
When installing marathon it gets (re)started twice, as enabling the service also starts it.
After the role finished the handler also (re)starts the service again.

By removing the optional (when `enabled` is used) `state` parameter it does not start at this at this task (but when the role finished), preventing (re)starting twice.