### PR TITLE
Restart marathon when (re)installed

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -7,3 +7,4 @@
 
 - name: Install Marathon package
   apt: pkg={{ marathon_apt_package }} state=present update_cache=yes
+  notify: Restart marathon

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -4,3 +4,4 @@
 
 - name: Install Marathon
   yum: name={{ marathon_yum_package }} state=present
+  notify: Restart marathon


### PR DESCRIPTION
After updating marathon (using apt), the framework was not restarted. This PR should fix that. 

(Also for RedHat, although I do not know whether yum restarts the framework by default...)