### PR TITLE
Update cache after adding the repository, not before installing the package

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,8 +3,8 @@
   apt_key: id=E56151BF keyserver=keyserver.ubuntu.com state=present
 
 - name: Add Mesosphere repo
-  apt_repository: repo="{{marathon_apt_repo}}" state=present
+  apt_repository: repo="{{marathon_apt_repo}}" state=present update_cache=yes
 
 - name: Install Marathon package
-  apt: pkg={{ marathon_apt_package }} state=present update_cache=yes
+  apt: pkg={{ marathon_apt_package }} state=present
   notify: Restart marathon


### PR DESCRIPTION
When the repo is added, a update cache is required to be able install Marathon.

When installing/updating Marathon a cache update is not required, as the OS will keep the cache up-to-date.

This prevents  changes when nothing actually changed (not idempotent).

Note that this PR probably conflicts with PR #38, when either one is merged back, I can update the other if required.