### PR TITLE
Enable apt pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ marathon_version: "1.3.6"
 # Debian: Mesosphere apt repository URL
 marathon_apt_package: "marathon={{ marathon_version }}-*"
 marathon_apt_repo: "deb http://repos.mesosphere.com/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main"
+# Debian apt pin priority for the marathon package. If empty (the default), no pin priority is used.
+marathon_apt_pin_priority:
 
 # RedHat: Mesosphere yum repository URL
 marathon_yum_package: "marathon-{{ marathon_version }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,11 @@ marathon_version: "1.3.6"
 marathon_repo_host: repo.mesosphere.com
 
 # Debian: Mesosphere apt repository URL
-marathon_apt_package: "marathon={{ marathon_version }}-*"
-marathon_apt_repo: "deb http://{{marathon_repo_host}}/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main"
+marathon_package_version: "1.0.540"
+marathon_apt_url: "http://{{ marathon_repo_host }}/{{ ansible_distribution | lower }}"
+marathon_os_distribution: "{{ ansible_distribution | lower }}"
+marathon_os_version: "{{ ansible_distribution_version.split('.') | join('') }}"
+marathon_apt_package: "marathon={{ marathon_version }}-{{ marathon_package_version }}.{{ marathon_os_distribution }}{{ marathon_os_version }}"
 
 # RedHat: Mesosphere yum repository URL
 marathon_yum_package: "marathon-{{ marathon_version }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 marathon_version: "1.3.6"
 
-marathon_repo_host: repo.mesosphere.com
+marathon_repo_host: repos.mesosphere.com
 
 # Debian: Mesosphere apt repository URL
 marathon_package_version: "1.0.540"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ marathon_apt_package: "marathon={{ marathon_package_full_version }}"
 
 # RedHat: Mesosphere yum repository URL
 marathon_yum_package: "marathon-{{ marathon_version }}"
-mesosphere_yum_repo: "http://{{ marathon_repo_host }}/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
+mesosphere_yum_repo: "https://{{ marathon_repo_host }}/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
 
 marathon_hostname: "{{ inventory_hostname }}"
 marathon_port: 8080

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,10 +5,11 @@ marathon_repo_host: repo.mesosphere.com
 
 # Debian: Mesosphere apt repository URL
 marathon_package_version: "1.0.540"
-marathon_apt_url: "http://{{ marathon_repo_host }}/{{ ansible_distribution | lower }}"
 marathon_os_distribution: "{{ ansible_distribution | lower }}"
 marathon_os_version: "{{ ansible_distribution_version.split('.') | join('') }}"
-marathon_apt_package: "marathon={{ marathon_version }}-{{ marathon_package_version }}.{{ marathon_os_distribution }}{{ marathon_os_version }}"
+marathon_apt_url: "http://{{ marathon_repo_host }}/{{ ansible_distribution | lower }}"
+marathon_package_full_version: "{{ marathon_version }}-{{ marathon_package_version }}.{{ marathon_os_distribution }}{{ marathon_os_version }}"
+marathon_apt_package: "marathon={{ marathon_package_full_version }}"
 
 # RedHat: Mesosphere yum repository URL
 marathon_yum_package: "marathon-{{ marathon_version }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,15 @@
 ---
 marathon_version: "1.3.6"
 
+marathon_repo_host: repo.mesosphere.com
+
 # Debian: Mesosphere apt repository URL
 marathon_apt_package: "marathon={{ marathon_version }}-*"
-marathon_apt_repo: "deb http://repos.mesosphere.com/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main"
+marathon_apt_repo: "deb http://{{marathon_repo_host}}/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} main"
 
 # RedHat: Mesosphere yum repository URL
 marathon_yum_package: "marathon-{{ marathon_version }}"
-mesosphere_yum_repo: "http://repos.mesosphere.com/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
+mesosphere_yum_repo: "http://{{ marathon_repo_host }}/el/{{ os_version_major }}/noarch/RPMS/{{ mesosphere_releases[os_version_major] }}"
 
 marathon_hostname: "{{ inventory_hostname }}"
 marathon_port: 8080

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -3,7 +3,13 @@
   apt_key: id=E56151BF keyserver=keyserver.ubuntu.com state=present
 
 - name: Add Mesosphere repo
-  apt_repository: repo="{{marathon_apt_repo}}" state=present update_cache=yes
+  apt_repository: repo='deb {{ marathon_apt_url }} {{ ansible_distribution_release | lower }} main' state=present update_cache=yes
+
+- name: Pin Marathon version
+  template:
+    src: marathon.pref.j2
+    dest: /etc/apt/preferences.d/marathon.pref
+  when: marathon_apt_pin_priority
 
 - name: Install Marathon package
   apt: pkg={{ marathon_apt_package }} state=present

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -9,7 +9,7 @@
   template:
     src: marathon.pref.j2
     dest: /etc/apt/preferences.d/marathon.pref
-  when: marathon_apt_pin_priority
+  when: marathon_apt_pin_priority | default(false) | bool
 
 - name: Install Marathon package
   apt: pkg={{ marathon_apt_package }} state=present

--- a/templates/marathon.pref.j2
+++ b/templates/marathon.pref.j2
@@ -1,0 +1,3 @@
+Package: marathon
+Pin: version {{ marathon_version }}-{{ marathon_package_version }}
+Pin-Priority: {{ marathon_apt_pin_priority }}

--- a/templates/marathon.pref.j2
+++ b/templates/marathon.pref.j2
@@ -1,3 +1,3 @@
 Package: marathon
-Pin: version {{ marathon_version }}-{{ marathon_package_version }}
+Pin: version {{ marathon_package_full_version }}
 Pin-Priority: {{ marathon_apt_pin_priority }}


### PR DESCRIPTION
### Short description:
Added optional apt pinning by setting the pin priority in `marathon_apt_pin_priority`(disabled by default)
Thx @scaronni for implementing 👍 

Same feature (PR) in the mesos-role https://github.com/AnsibleShipyard/ansible-mesos/pull/81